### PR TITLE
handle error on the iwconfig parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,13 @@ IW.prototype = new EventEmitter;
 IW.prototype.associated = function(cb) {
     exec('iwconfig ' + this.iface, function(err, stdout, stderr) {
         if (err) return cb(err)
-        var status = stdout.match(/Access Point: (.*)\n/)[1]
-        if (status.match(/Not-Associated/)) return cb(false, false)
-        cb(false, true)
+        try {
+            var status = stdout.match(/Access Point: (.*)\n/)[1]
+            if (status.match(/Not-Associated/)) return cb(false, false)
+            cb(false, true)
+        } catch(e) {
+            cb(e)
+        }
     })
 }
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+Fork from https://github.com/maxogden/iwlist
+
 # iwlist
 
 parses iwlist output on linux computers. tested on raspberry pi running raspbian (debian)
@@ -7,7 +9,7 @@ parses iwlist output on linux computers. tested on raspberry pi running raspbian
 ## install
 
 ```javascript
-npm install iwlist
+npm install TheThingBox/iwlist
 ```
 
 ## instantiate


### PR DESCRIPTION
The `iwconfig wlan0` command can return something like : 
``` txt
wlan0     IEEE 802.11  Mode:Master  Tx-Power=31 dBm   
          Retry short limit:7   RTS thr:off   Fragment thr:off
          Power Management:on
```
There are no 'Access Point' to match